### PR TITLE
fix integer check

### DIFF
--- a/mknapsack/_utils.py
+++ b/mknapsack/_utils.py
@@ -20,4 +20,4 @@ def pad_array(ar, width):
 
 def check_all_int(ar):
     """Check if all input values are integers."""
-    return all(i == 0 or i % int(i) == 0 for i in ar)
+    return all(i - int(i) == 0 for i in ar)

--- a/mknapsack/tests/test__single.py
+++ b/mknapsack/tests/test__single.py
@@ -19,6 +19,15 @@ single_knapsack_case_small = {
     'solution': [0, 1, 1, 1, 1, 1, 1, 0, 0, 0]
 }
 
+single_knapsack_case_small_real = {
+    'case': 'small-real',
+    'profits': [16, 78, 35, 89, 36, 94, 75, 74, 100, 80],
+    'weights': [30, 18, 0.4, 23, 20, 59, 61, 70, 75, 76],
+    'capacity': 190,
+    'total_profit': 407,
+    'solution': [0, 1, 1, 1, 1, 1, 1, 0, 0, 0]
+}
+
 single_knapsack_case_small_reverse = {  # Ensure ordering works
     'case': 'small-reverse',
     'profits': [16, 78, 35, 89, 36, 94, 75, 74, 100, 80][::-1],
@@ -71,6 +80,7 @@ single_knapsack_success_cases = [
     {'method': 'mt2', **single_knapsack_case_large},
     {'method': 'mt1r', **single_knapsack_case_small, 'tolerance': 1e-07},
     {'method': 'mt1r', **single_knapsack_case_medium, 'tolerance': 1e-07},
+    {'method': 'mt1r', **single_knapsack_case_small_real, 'tolerance': 1e-07},
     {'method': 'mt1r', **single_knapsack_case_medium_real, 'tolerance': 1e-07}
 ]
 


### PR DESCRIPTION
Hi, calling `check_all_int` [1] with floating-point numbers < 1, e.g.
```
check_all_int([0.5])
```
results in 
```
ZeroDivisionError: float modulo
```
Reason is mainly that `int(0.5)=0` and then `i % int(i)` is undefined.

This happens for example when solving 0-1-knapsack with profits, weights or capacity < 1 (method="mt1r") [2]. Note that we don't have to check if the values are integers if the method is already "mt1r", so changing `check_all_int` is just a quick-fix and not a code refactoring.

Hope it helps, thank you!

[1] https://github.com/jmyrberg/mknapsack/blob/master/mknapsack/_utils.py#L21
[2] https://github.com/jmyrberg/mknapsack/blob/master/mknapsack/_single.py#L95
